### PR TITLE
Rename "MoveGroupExecuteService" to "MoveGroupExecuteTrajectoryAction".

### DIFF
--- a/iiwa_tool/iiwa_tool_moveit/launch/move_group.launch
+++ b/iiwa_tool/iiwa_tool_moveit/launch/move_group.launch
@@ -59,7 +59,7 @@
 
     <!-- MoveGroup capabilities to load -->
     <param name="capabilities" value="move_group/MoveGroupCartesianPathService
-				      move_group/MoveGroupExecuteService
+				      move_group/MoveGroupExecuteTrajectoryAction
 				      move_group/MoveGroupKinematicsService
 				      move_group/MoveGroupMoveAction
 				      move_group/MoveGroupPickPlaceAction


### PR DESCRIPTION
It has been decprecated by MoveIt.